### PR TITLE
Add missing unitree_go msgs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(ament_cmake REQUIRED)
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
 
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(rosidl_generator_dds_idl REQUIRED)
 
@@ -30,6 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
         "msg/BmsCmd.msg"
         "msg/BmsState.msg"
         "msg/Error.msg"
+        "msg/Go2FrontVideoData.msg"
         "msg/HeightMap.msg"
         "msg/IMUState.msg"
         "msg/InterfaceConfig.msg"
@@ -48,8 +48,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
         "msg/TimeSpec.msg"
         "msg/UwbState.msg"
         "msg/UwbSwitch.msg"
+        "msg/VoxelMapCompressed.msg"
+        "msg/VoxelHeightMapState.msg"
         "msg/WirelessController.msg"
-  DEPENDENCIES geometry_msgs
 )
 
 rosidl_generate_dds_interfaces(

--- a/msg/Go2FrontVideoData.msg
+++ b/msg/Go2FrontVideoData.msg
@@ -1,0 +1,8 @@
+# Time frame as a 64-bit unsigned integer
+uint64 time_frame
+
+# Resolution as a 16-bit signed integer
+int16 resolution
+
+# Data as a sequence of bytes (octets)
+uint8[] data

--- a/msg/VoxelHeightMapState.msg
+++ b/msg/VoxelHeightMapState.msg
@@ -1,0 +1,14 @@
+# Timestamp (in seconds since epoch)
+float64 stamp
+
+# Timestamp for the point cloud (in seconds)
+float64 stamp_cloud
+
+# Timestamp for odometry (in seconds)
+float64 stamp_odom
+
+# Size of the height map
+uint32 height_map_size
+
+# Size of the voxel map
+uint32 voxel_map_size

--- a/msg/VoxelMapCompressed.msg
+++ b/msg/VoxelMapCompressed.msg
@@ -1,0 +1,21 @@
+# Timestamp (in seconds since epoch)
+float64 stamp
+
+# Frame ID for the coordinate frame
+string frame_id
+
+# Resolution of the voxel map
+float64 resolution
+
+# Origin of the voxel map (x, y, z)
+float64[3] origin
+
+# Width of the voxel map in each dimension (x, y, z)
+int16[3] width
+
+# Source size of the compressed data
+uint64 src_size
+
+# Compressed voxel data
+uint8[] data
+

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,6 @@
   <member_of_group>rosidl_interface_packages</member_of_group>
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>geometry_msgs</depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Missing msgs from the `unitree_go` namespace. Required for voxel grid decompression and video stream decoding.